### PR TITLE
changes for deploying/un-deploying sub-databases

### DIFF
--- a/src/main/java/com/marklogic/appdeployer/command/databases/DeployContentDatabasesCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/databases/DeployContentDatabasesCommand.java
@@ -77,6 +77,10 @@ public class DeployContentDatabasesCommand extends DeployDatabaseCommand {
             String json = payloadTokenReplacer.replaceTokens(payload, appConfig, false);
 
             DatabaseManager dbMgr = newDatabaseManageForDeleting(context);
+            
+            // remove subdatabases if they exist
+            removeSubDatabases(dbMgr, context, dbMgr.getResourceId(json));
+            
             dbMgr.delete(json);
             if (appConfig.isTestPortSet()) {
                 json = payloadTokenReplacer.replaceTokens(payload, appConfig, true);

--- a/src/main/java/com/marklogic/mgmt/resource/databases/DatabaseManager.java
+++ b/src/main/java/com/marklogic/mgmt/resource/databases/DatabaseManager.java
@@ -55,6 +55,44 @@ public class DatabaseManager extends AbstractResourceManager {
         getManageClient().postJson(path, format("{\"operation\":\"%s\"}", operation));
         logger.info(format("Finished invoking operation %s on database %s", operation, databaseIdOrName));
     }
+    
+    public String getResourceId(String payload){
+    	return super.getResourceId(payload);
+    }
+    
+    /**
+     * Detaches or disassociates any sub-databases from this database
+     * @param databaseIdOrName
+     */
+    public void detachSubDatabases(String databaseIdOrName){
+    	logger.info("Detaching sub-databases from database: " + databaseIdOrName);
+    	save(format("{\"database-name\":\"%s\", \"subdatabase\": []}", databaseIdOrName));
+    	logger.info("Finished detaching sub-databases from database: " + databaseIdOrName);
+    }
+    
+    /**
+     * Attaches/associates the specified databases with this database, making it a super-database.
+     * Note: that the databases listed in subDbNames must have already been created.
+     * 
+     * @param databaseIdOrName
+     * @param subDbNames
+     */
+    public void attachSubDatabases(String databaseIdOrName, List<String> subDbNames){
+    	String payload = format("{\"database-name\":\"%s\", \"subdatabase\": [", databaseIdOrName);
+    	for(int index = 0; index < subDbNames.size(); index++){
+    		if(index > 0){ payload += ","; }
+    		payload += format("{\"database-name\":\"%s\"}", subDbNames.get(index));
+    	}
+    	payload += "]}";
+    	logger.info("Attaching sub-databases to database: " + databaseIdOrName + ", using configured payload: " + payload);
+    	save(payload);
+    	logger.info("Finished attaching sub-databases to database: " + databaseIdOrName);
+    	
+    }
+    
+    public List<String> getSubDatabases(String databaseNameOrId) {
+    	return getPropertiesAsXml(databaseNameOrId).getElementValues("/node()/m:subdatabases/m:subdatabase/m:database-name");
+    }
 
     public void deleteByName(String databaseName) {
         String json = format("{\"database-name\":\"%s\"}", databaseName);

--- a/src/test/java/com/marklogic/appdeployer/command/databases/DeployDatabasesAndSubDatabasesTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/databases/DeployDatabasesAndSubDatabasesTest.java
@@ -1,0 +1,56 @@
+package com.marklogic.appdeployer.command.databases;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.marklogic.appdeployer.AbstractAppDeployerTest;
+import com.marklogic.appdeployer.ConfigDir;
+import com.marklogic.appdeployer.command.restapis.DeployRestApiServersCommand;
+import com.marklogic.mgmt.resource.databases.DatabaseManager;
+
+public class DeployDatabasesAndSubDatabasesTest extends AbstractAppDeployerTest{
+    @Test
+    public void test() {
+        ConfigDir configDir = appConfig.getConfigDir();
+        configDir.setBaseDir(new File("src/test/resources/sample-app/subdatabases"));
+
+        initializeAppDeployer(new DeployRestApiServersCommand(), new DeployContentDatabasesCommand(2),
+                new DeployTriggersDatabaseCommand(), new DeploySchemasDatabaseCommand(),
+                new DeployOtherDatabasesCommand());
+
+        DatabaseManager dbMgr = new DatabaseManager(manageClient);
+
+        String[] dbNames = new String[] { "sample-app-content", "sample-app-triggers", "sample-app-schemas",
+                "mysuperdb", "mysuperdb-subdb01", "mysuperdb-subdb02", "sample-app-content-subdb01", "sample-app-content-subdb01" };
+        try {
+            appDeployer.deploy(appConfig);
+
+            for (String name : dbNames) {
+                assertTrue("Expected to find database: " + name, dbMgr.exists(name));
+            }
+            
+        	// check that subdatabases are associated 
+            List<String> subDatabases = dbMgr.getSubDatabases("mysuperdb");
+            assertTrue("Expected to find subdatabase of 'mysuperdb-subdb01'", subDatabases.contains("mysuperdb-subdb01"));
+            assertTrue("Expected to find subdatabase of 'mysuperdb-subdb02'", subDatabases.contains("mysuperdb-subdb02"));
+
+            subDatabases = dbMgr.getSubDatabases("sample-app-content");
+            assertTrue("Expected to find subdatabase of 'sample-app-content-subdb01'", subDatabases.contains("sample-app-content-subdb01"));
+            assertTrue("Expected to find subdatabase of 'sample-app-content-subdb02'", subDatabases.contains("sample-app-content-subdb02"));
+            
+
+        } finally {
+            
+            undeploySampleApp();
+
+            for (String name : dbNames) {
+                assertFalse("Expected to not find database: " + name, dbMgr.exists(name));
+            }
+            
+            
+        }
+    }
+
+}

--- a/src/test/resources/sample-app/subdatabases/databases/content-database.json
+++ b/src/test/resources/sample-app/subdatabases/databases/content-database.json
@@ -1,0 +1,23 @@
+{
+  "database-name": "%%DATABASE%%",
+  "triggers-database": "%%TRIGGERS_DATABASE%%",
+  "schema-database": "%%SCHEMAS_DATABASE%%",
+  "range-element-index" : [
+	{
+     	"invalid-values" : "reject",
+        "collation" : "http://marklogic.com/collation/",
+        "localname" : "FirstName",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "string"
+    },
+    {
+    	"invalid-values" : "reject",
+        "collation" : "",
+        "localname" : "BirthDate",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "dateTime"
+    }
+  ]
+}

--- a/src/test/resources/sample-app/subdatabases/databases/my-super-db.json
+++ b/src/test/resources/sample-app/subdatabases/databases/my-super-db.json
@@ -1,0 +1,23 @@
+{
+  "database-name": "mysuperdb",
+  "triggers-database": "%%TRIGGERS_DATABASE%%",
+  "schema-database": "%%SCHEMAS_DATABASE%%",
+  "range-element-index" : [
+	{
+     	"invalid-values" : "reject",
+        "collation" : "http://marklogic.com/collation/",
+        "localname" : "FirstName",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "string"
+    },
+    {
+    	"invalid-values" : "reject",
+        "collation" : "",
+        "localname" : "BirthDate",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "dateTime"
+    }
+  ]  
+}

--- a/src/test/resources/sample-app/subdatabases/databases/schemas-database.json
+++ b/src/test/resources/sample-app/subdatabases/databases/schemas-database.json
@@ -1,0 +1,3 @@
+{
+  "database-name": "%%SCHEMAS_DATABASE%%"
+}

--- a/src/test/resources/sample-app/subdatabases/databases/subdatabases/mysuperdb/mysuperdb-subdb01.json
+++ b/src/test/resources/sample-app/subdatabases/databases/subdatabases/mysuperdb/mysuperdb-subdb01.json
@@ -1,0 +1,21 @@
+{
+  "database-name": "mysuperdb-subdb01",
+  "range-element-index" : [
+	{
+     	"invalid-values" : "reject",
+        "collation" : "http://marklogic.com/collation/",
+        "localname" : "FirstName",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "string"
+    },
+    {
+    	"invalid-values" : "reject",
+        "collation" : "",
+        "localname" : "BirthDate",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "dateTime"
+    }
+  ]
+}

--- a/src/test/resources/sample-app/subdatabases/databases/subdatabases/mysuperdb/mysuperdb-subdb02.json
+++ b/src/test/resources/sample-app/subdatabases/databases/subdatabases/mysuperdb/mysuperdb-subdb02.json
@@ -1,0 +1,21 @@
+{
+  "database-name": "mysuperdb-subdb02",
+  "range-element-index" : [
+	{
+     	"invalid-values" : "reject",
+        "collation" : "http://marklogic.com/collation/",
+        "localname" : "FirstName",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "string"
+    },
+    {
+    	"invalid-values" : "reject",
+        "collation" : "",
+        "localname" : "BirthDate",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "dateTime"
+    }
+  ]
+}

--- a/src/test/resources/sample-app/subdatabases/databases/subdatabases/sample-app-content/sample-app-content-subdb01.json
+++ b/src/test/resources/sample-app/subdatabases/databases/subdatabases/sample-app-content/sample-app-content-subdb01.json
@@ -1,0 +1,21 @@
+{
+  "database-name": "sample-app-content-subdb01",
+  "range-element-index" : [
+	{
+     	"invalid-values" : "reject",
+        "collation" : "http://marklogic.com/collation/",
+        "localname" : "FirstName",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "string"
+    },
+    {
+    	"invalid-values" : "reject",
+        "collation" : "",
+        "localname" : "BirthDate",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "dateTime"
+    }
+  ]
+}

--- a/src/test/resources/sample-app/subdatabases/databases/subdatabases/sample-app-content/sample-app-content-subdb02.json
+++ b/src/test/resources/sample-app/subdatabases/databases/subdatabases/sample-app-content/sample-app-content-subdb02.json
@@ -1,0 +1,21 @@
+{
+  "database-name": "sample-app-content-subdb02",
+  "range-element-index" : [
+	{
+     	"invalid-values" : "reject",
+        "collation" : "http://marklogic.com/collation/",
+        "localname" : "FirstName",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "string"
+    },
+    {
+    	"invalid-values" : "reject",
+        "collation" : "",
+        "localname" : "BirthDate",
+        "namespace-uri" : "http://person",
+        "range-value-positions" : false,
+        "scalar-type" : "dateTime"
+    }
+  ]
+}

--- a/src/test/resources/sample-app/subdatabases/databases/triggers-database.json
+++ b/src/test/resources/sample-app/subdatabases/databases/triggers-database.json
@@ -1,0 +1,3 @@
+{
+  "database-name": "%%TRIGGERS_DATABASE%%"
+}


### PR DESCRIPTION
Rob,
Seems like there are several ways to go with this, here is one approach. This method has subdatabases defined in /databases/subdatabases. So, if mydb needs two sub-databases, mydb-sub01 and mydb-sub02, it would be configured as below:

/databases/mydb.json
/databases/subdatabases/mydb/mydb-sub01.json
/databases/subdatabases/mydb/mydb-sub02.json

So any databases that you want to configure sub-databases for, need to have a folder in sub-databases named after the database. For each database in that folder, a database is created and attached to the main database as a sub-database. When undeployed, any sub-databases are first detached, then deleted.

It is expected that the user adds the same element range indexes/etc in the main database and all sub-databases config files. Although we could update to take them from the main database and automatically use that for the sub-databases.

I did look at issue #204 (https://github.com/marklogic-community/ml-gradle/issues/204) in ml-gradle. It seems like specifying sub-database in the database config expects the sub-databases to already exist. This seems more appropriate for databases that are in a different cluster maybe where that cluster has already been created?

Along those lines, this solution doesn't support specifying a cluster when attaching sub-databases to a database. If we want to do that, we'll have to find a place to put the cluster name.

Take a look and see if you think this solution handles how you think people might use/configure sub-databases.

 