### PR TITLE
#201 Deploying servers now accounts for group-name in payload

### DIFF
--- a/src/main/java/com/marklogic/appdeployer/command/AbstractCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/AbstractCommand.java
@@ -132,11 +132,23 @@ public abstract class AbstractCommand extends LoggingObject implements Command {
      */
     protected SaveReceipt saveResource(ResourceManager mgr, CommandContext context, File f) {
 		String payload = copyFileToString(f, context);
+		mgr = adjustResourceManagerForPayload(mgr, context, payload);
         SaveReceipt receipt = mgr.save(payload);
         if (storeResourceIdsAsCustomTokens) {
             storeTokenForResourceId(receipt, context);
         }
         return receipt;
+    }
+
+	/**
+	 * A subclass can override this when the ResourceManager needs to be adjusted based on data in the payload.
+	 *
+	 * @param mgr
+	 * @param payload
+	 * @return
+	 */
+	protected ResourceManager adjustResourceManagerForPayload(ResourceManager mgr, CommandContext context, String payload) {
+    	return mgr;
     }
 
     /**

--- a/src/main/java/com/marklogic/appdeployer/command/AbstractResourceCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/AbstractResourceCommand.java
@@ -125,18 +125,19 @@ public abstract class AbstractResourceCommand extends AbstractUndoableCommand {
      * @param context
      * @param f
      */
-    protected void deleteResource(final ResourceManager mgr, CommandContext context, File f) {
+    protected void deleteResource(ResourceManager mgr, CommandContext context, File f) {
         final String payload = copyFileToString(f, context);
+        final ResourceManager resourceManager = adjustResourceManagerForPayload(mgr, context, payload);
         try {
             if (restartAfterDelete) {
                 context.getAdminManager().invokeActionRequiringRestart(new ActionRequiringRestart() {
                     @Override
                     public boolean execute() {
-                        return mgr.delete(payload).isDeleted();
+                        return resourceManager.delete(payload).isDeleted();
                     }
                 });
             } else {
-                mgr.delete(payload);
+	            resourceManager.delete(payload);
             }
         } catch (RuntimeException e) {
             if (catchExceptionOnDeleteFailure) {

--- a/src/main/java/com/marklogic/appdeployer/command/appservers/DeployOtherServersCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/appservers/DeployOtherServersCommand.java
@@ -4,8 +4,11 @@ import com.marklogic.appdeployer.command.AbstractResourceCommand;
 import com.marklogic.appdeployer.command.CommandContext;
 import com.marklogic.appdeployer.command.ResourceFilenameFilter;
 import com.marklogic.appdeployer.command.SortOrderConstants;
+import com.marklogic.mgmt.PayloadParser;
+import com.marklogic.mgmt.SaveReceipt;
 import com.marklogic.mgmt.resource.ResourceManager;
 import com.marklogic.mgmt.resource.appservers.ServerManager;
+import com.marklogic.mgmt.util.ObjectMapperFactory;
 
 import java.io.File;
 
@@ -38,4 +41,21 @@ public class DeployOtherServersCommand extends AbstractResourceCommand {
         return 0;
     }
 
+	/**
+	 * If the payload has a group-name that differs from the group name in the AppConfig, then this returns a new
+	 * ServerManager using the group-name in the payload.
+	 *
+	 * @param mgr
+	 * @param context
+	 * @param payload
+	 * @return
+	 */
+	@Override
+	protected ResourceManager adjustResourceManagerForPayload(ResourceManager mgr, CommandContext context, String payload) {
+		String groupName = new PayloadParser().getPayloadFieldValue(payload, "group-name", false);
+		if (groupName != null && !groupName.equals(context.getAppConfig().getGroupName())) {
+			return new ServerManager(context.getManageClient(), groupName);
+		}
+		return mgr;
+	}
 }

--- a/src/main/java/com/marklogic/mgmt/PayloadParser.java
+++ b/src/main/java/com/marklogic/mgmt/PayloadParser.java
@@ -28,20 +28,31 @@ public class PayloadParser {
         return getPayloadFieldValue(payload, idFieldName);
     }
 
-    public String getPayloadFieldValue(String payload, String fieldName) {
+	public String getPayloadFieldValue(String payload, String fieldName) {
+    	return getPayloadFieldValue(payload, fieldName, true);
+	}
+
+	public String getPayloadFieldValue(String payload, String fieldName, boolean throwErrorIfNotFound) {
         if (isJsonPayload(payload)) {
             JsonNode node = parseJson(payload);
             if (!node.has(fieldName)) {
-                throw new RuntimeException("Cannot get field value from JSON; field name: " + fieldName + "; JSON: "
-                        + payload);
+            	if (throwErrorIfNotFound) {
+		            throw new RuntimeException("Cannot get field value from JSON; field name: " + fieldName + "; JSON: "
+			            + payload);
+	            } else {
+            		return null;
+	            }
             }
             return node.get(fieldName).isTextual() ? node.get(fieldName).asText() : node.get(fieldName).toString();
-
         } else {
             Fragment f = new Fragment(payload);
             String xpath = String.format("/node()/*[local-name(.) = '%s']", fieldName);
             if (!f.elementExists(xpath)) {
-                throw new RuntimeException("Cannot get field value from XML at path: " + xpath + "; XML: " + payload);
+            	if (throwErrorIfNotFound) {
+		            throw new RuntimeException("Cannot get field value from XML at path: " + xpath + "; XML: " + payload);
+	            } else {
+            		return null;
+	            }
             }
             return f.getElementValues(xpath).get(0);
         }

--- a/src/test/java/com/marklogic/appdeployer/command/servers/UpdateServerInOtherGroupTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/servers/UpdateServerInOtherGroupTest.java
@@ -1,0 +1,46 @@
+package com.marklogic.appdeployer.command.servers;
+
+import com.marklogic.appdeployer.AbstractAppDeployerTest;
+import com.marklogic.appdeployer.ConfigDir;
+import com.marklogic.appdeployer.command.appservers.DeployOtherServersCommand;
+import com.marklogic.appdeployer.command.groups.DeployGroupsCommand;
+import com.marklogic.mgmt.resource.appservers.ServerManager;
+import com.marklogic.mgmt.resource.groups.GroupManager;
+import org.junit.Test;
+
+import java.io.File;
+
+public class UpdateServerInOtherGroupTest extends AbstractAppDeployerTest {
+
+	@Test
+	public void test() {
+		appConfig.setConfigDir(new ConfigDir(new File("src/test/resources/sample-app/other-group")));
+
+		appConfig.setGroupName("Default");
+
+		final String otherGroup = "sample-app-other-group";
+		final String otherServer = "sample-app-other-server";
+
+		GroupManager groupManager = new GroupManager(manageClient);
+		ServerManager serverManager = new ServerManager(manageClient);
+
+		initializeAppDeployer(new DeployGroupsCommand(), new DeployOtherServersCommand());
+
+		try {
+			deploySampleApp();
+
+			assertTrue(groupManager.exists(otherGroup));
+			assertTrue(serverManager.exists(otherServer));
+
+			// Now deploy it again, verifying no errors - i.e. that the other group name is included correctly in the call to update the server
+			deploySampleApp();
+
+			assertTrue(groupManager.exists(otherGroup));
+			assertTrue(serverManager.exists(otherServer));
+
+		} finally {
+			undeploySampleApp();
+		}
+	}
+
+}

--- a/src/test/resources/sample-app/other-group/groups/sample-app-other-group.json
+++ b/src/test/resources/sample-app/other-group/groups/sample-app-other-group.json
@@ -1,0 +1,3 @@
+{
+	"group-name": "sample-app-other-group"
+}

--- a/src/test/resources/sample-app/other-group/servers/http-server.json
+++ b/src/test/resources/sample-app/other-group/servers/http-server.json
@@ -1,0 +1,9 @@
+{
+  "server-name": "sample-app-other-server",
+  "server-type": "http",
+  "root": "/",
+  "group-name": "sample-app-other-group",
+  "port": 8048,
+  "modules-database": "Modules",
+  "content-database": "Documents"
+}


### PR DESCRIPTION
@cskeefer Take a look at this - it solves the problem at the command level instead of the manager level (I think it makes sense that a Manager is constructed for a particular group, as opposed to the Manager having to worry about overriding the group that it's given). 

This also handles when the server is undeployed - the group-name in the payload will be used. 