### PR TITLE
Issue #258 use security config for query rolesets and protected paths

### DIFF
--- a/src/main/java/com/marklogic/mgmt/resource/security/ProtectedPathManager.java
+++ b/src/main/java/com/marklogic/mgmt/resource/security/ProtectedPathManager.java
@@ -14,6 +14,11 @@ public class ProtectedPathManager extends AbstractResourceManager {
 	}
 
 	@Override
+	protected boolean useSecurityUser() {
+		return true;
+	}
+
+	@Override
 	public String getResourcesPath() {
 		return "/manage/v2/protected-paths";
 	}

--- a/src/main/java/com/marklogic/mgmt/resource/security/QueryRolesetsManager.java
+++ b/src/main/java/com/marklogic/mgmt/resource/security/QueryRolesetsManager.java
@@ -17,6 +17,11 @@ public class QueryRolesetsManager extends AbstractResourceManager {
 	}
 
 	@Override
+	protected boolean useSecurityUser() {
+		return true;
+	}
+
+	@Override
 	public String getResourcesPath() {
 		return "/manage/v2/query-rolesets";
 	}


### PR DESCRIPTION
I think this is pretty straightforward -- ran into the issue while implementing PII deployments for DHF.