### PR TITLE
Fixing #266

### DIFF
--- a/src/main/java/com/marklogic/appdeployer/command/AbstractCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/AbstractCommand.java
@@ -104,7 +104,7 @@ public abstract class AbstractCommand extends LoggingObject implements Command {
      */
     protected String copyFileToString(File f) {
         try {
-            return new String(FileCopyUtils.copyToByteArray(f));
+            return new String(FileCopyUtils.copyToByteArray(f.getAbsoluteFile()));
         } catch (IOException ie) {
             throw new RuntimeException(
                     "Unable to copy file to string from path: " + f.getAbsolutePath() + "; cause: " + ie.getMessage(),


### PR DESCRIPTION
Running tasks like mlDeploy using a gradle daemon resulted in a NoSuchFileException on windows.
Using a gradle daemon the current working directory seems to be somewhere
in `$USER_HOME/.gradle/daemon/$version`.
copyFileToString then tried to resolve the file relative to this path.
Converting to absolute path beforehand.