### PR TITLE
Exclude id field from payloads for mgmt API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=com.marklogic
 javadocsDir=../gh-pages-marklogic-java/javadocs
-version=3.9.0
+version=3.9.1
 mlJavaclientUtilVersion=3.8.1
 mlJunitVersion=3.1.0
 

--- a/src/main/java/com/marklogic/mgmt/AbstractManager.java
+++ b/src/main/java/com/marklogic/mgmt/AbstractManager.java
@@ -62,9 +62,6 @@ public class AbstractManager extends LoggingObject {
         boolean requiresSecurityUser = useSecurityUser(payload);
         try {
 	        if (payloadParser.isJsonPayload(payload)) {
-	        	// remove resourceID from payload for DHS.
-				// should be safe for all payloads though.
-				payload = payloadParser.excludeProperties(payload, getIdFieldName());
 		        return requiresSecurityUser ? client.putJsonAsSecurityUser(path, payload) : client.putJson(path, payload);
 	        }
 	        return requiresSecurityUser ? client.putXmlAsSecurityUser(path, payload) : client.putXml(path, payload);

--- a/src/main/java/com/marklogic/mgmt/AbstractManager.java
+++ b/src/main/java/com/marklogic/mgmt/AbstractManager.java
@@ -62,6 +62,9 @@ public class AbstractManager extends LoggingObject {
         boolean requiresSecurityUser = useSecurityUser(payload);
         try {
 	        if (payloadParser.isJsonPayload(payload)) {
+	        	// remove resourceID from payload for DHS.
+				// should be safe for all payloads though.
+				payload = payloadParser.excludeProperties(payload, getIdFieldName());
 		        return requiresSecurityUser ? client.putJsonAsSecurityUser(path, payload) : client.putJson(path, payload);
 	        }
 	        return requiresSecurityUser ? client.putXmlAsSecurityUser(path, payload) : client.putXml(path, payload);

--- a/src/main/java/com/marklogic/mgmt/resource/databases/DatabaseManager.java
+++ b/src/main/java/com/marklogic/mgmt/resource/databases/DatabaseManager.java
@@ -4,6 +4,7 @@ import com.marklogic.mgmt.resource.AbstractResourceManager;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.resource.forests.ForestManager;
 import com.marklogic.rest.util.Fragment;
+import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +21,28 @@ public class DatabaseManager extends AbstractResourceManager {
         super(manageClient);
     }
 
-    /**
+	/**
+	 * This is being added in 3.9.1 to add support for when a database is updated by a user that only has privileges
+	 * to update indexes. In such a scenario, the database-name property cannot exist, even if it's not changing. It's
+	 * also not needed, because the URL for the request specifies the database to update.
+	 *
+	 * It may be safe to make this change for all resource property updates, but it's only being applied for databases
+	 * since that's the immediate need for the Data Hub Framework.
+	 *
+	 * @param client
+	 * @param path
+	 * @param payload
+	 * @return
+	 */
+	@Override
+	protected ResponseEntity<String> putPayload(ManageClient client, String path, String payload) {
+		if (payloadParser.isJsonPayload(payload)) {
+			payload = payloadParser.excludeProperties(payload, getIdFieldName());
+		}
+		return super.putPayload(client, path, payload);
+	}
+
+	/**
      * This will catch and log any exception by default, as the most frequent reason why this fails is because the
      * database doesn't exist yet.
      *

--- a/src/test/java/com/marklogic/appdeployer/command/databases/CreateAndUpdateDatabaseTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/databases/CreateAndUpdateDatabaseTest.java
@@ -1,0 +1,28 @@
+package com.marklogic.appdeployer.command.databases;
+
+import com.marklogic.appdeployer.AbstractAppDeployerTest;
+import org.junit.Test;
+
+import java.io.File;
+
+public class CreateAndUpdateDatabaseTest extends AbstractAppDeployerTest {
+
+	/**
+	 * TODO Update this test to perform the second deployment as a user that only has privileges to update indexes.
+	 *
+	 */
+	@Test
+	public void test() {
+		appConfig.getFirstConfigDir().setBaseDir(new File("src/test/resources/sample-app/db-only-config"));
+
+		DeployContentDatabasesCommand command = new DeployContentDatabasesCommand(1);
+		initializeAppDeployer(command);
+
+		try {
+			deploySampleApp();
+			deploySampleApp();
+		} finally {
+			undeploySampleApp();
+		}
+	}
+}


### PR DESCRIPTION
Hi @rjrudin when i messaged you yesterday it was about this change.

We have granular privileges in DHS such that the developer can only modify indexes, not configure other aspects of database.  'database-name' is such a property -- if you submit it in the DHS environment, you'll get a 403, even though this property is effectively a no-op.

Indeed, in ml-app-deployer, this property (any ID property for a resource) will be in effect a no-op, since its used to create the mgmt API URL.

So this change actually strips that property from the payload, which enables DHF developers to configure indexes in DHS, even if they don't create or configure dbs in other ways.