### PR TITLE
Fix deployment of ssl certs in a cluster

### DIFF
--- a/src/main/java/com/marklogic/appdeployer/command/AbstractCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/AbstractCommand.java
@@ -199,7 +199,6 @@ public abstract class AbstractCommand extends LoggingObject implements Command {
 	 * an ObjectNode, which is the preferred data structure for merging resources together, and then stashing that
 	 * ObjectNode in the CommandContext map.
 	 *
-	 * @return
 	 */
 	protected void storeResourceInCommandContextMap(CommandContext context, File resourceFile, String payload) {
 		final String contextKey = getContextKeyForResourcesToSave();
@@ -350,7 +349,6 @@ public abstract class AbstractCommand extends LoggingObject implements Command {
 	 * adjustPayloadBeforeSavingResource. This is in a separate method for subclasses to use that needs to read in the
 	 * contents of a file but don't wish to use saveResource.
 	 *
-	 * @param mgr
 	 * @param context
 	 * @param f
 	 * @return

--- a/src/main/java/com/marklogic/appdeployer/command/security/InsertCertificateHostsTemplateCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/security/InsertCertificateHostsTemplateCommand.java
@@ -76,12 +76,15 @@ public class InsertCertificateHostsTemplateCommand extends AbstractCommand {
 	/**
 	 * @param context
 	 * @param templateName The name of the certificate template that the host certificate will be inserted into
+	 * 	Assumes filename is hostname + .crt: ex: host1.marklogic.com.crt
 	 * @param publicCertFile
 	 * @param privateKeyFile
 	 */
 	protected void insertHostCertificate(CommandContext context, String templateName, File publicCertFile, File privateKeyFile) {
 		CertificateTemplateManager mgr = new CertificateTemplateManager(context.getManageClient());
-		if (!mgr.certificateExists(templateName)) {
+		int spot = publicCertFile.getName().toLowerCase().indexOf(".crt");
+		String certHostName = publicCertFile.getName().substring(0, spot);
+		if (!mgr.certificateExists(templateName, certHostName)) {
 			logger.info(format("Inserting host certificate for certificate template '%s'", templateName));
 			String pubCertString = copyFileToString(publicCertFile);
 			String privateKeyString = copyFileToString(privateKeyFile);

--- a/src/main/java/com/marklogic/mgmt/resource/security/CertificateTemplateManager.java
+++ b/src/main/java/com/marklogic/mgmt/resource/security/CertificateTemplateManager.java
@@ -116,13 +116,13 @@ public class CertificateTemplateManager extends AbstractResourceManager {
 	 *
 	 * Used because ML9.0-5 (and prior) has bug for "needs-certificate" call
 	 */
-	public boolean certificateExists(String templateIdOrName) {
+	public boolean certificateExists(String templateIdOrName, String certHostName) {
 		Fragment response = getCertificatesForTemplate(templateIdOrName);
 		if (logger.isDebugEnabled()) {
 			logger.debug(format("Checking if %s template has certificates --> for template: %s", templateIdOrName, response.getPrettyXml()));
 		}
 
-		return response.elementExists("/msec:certificate-list/msec:certificate");
+		return response.elementExists("/msec:certificate-list/msec:certificate[./msec:host-name = '" + certHostName + "']");
 	}
 
     public Fragment getCertificatesForTemplate(String templateIdOrName) {


### PR DESCRIPTION
Fixes issue with #419 

certificateExists method must check for existence based on host-name.  This way more nodes can be added to the cluster without interfering with existing certs.