### PR TITLE
442 Log warning instead of throwing error when database directory isn't associated to a real database

### DIFF
--- a/src/main/java/com/marklogic/appdeployer/command/AbstractCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/AbstractCommand.java
@@ -509,7 +509,10 @@ public abstract class AbstractCommand extends LoggingObject implements Command {
 	 * within the directory should be associated with. But starting in 3.16.0, if the name of the directory doesn't
 	 * match that of an existing database, then a check is made to see if there's a database file in the given ConfigDir
 	 * that has the same name, minus its extension, as the database directory name. If so, then the database-name is
-	 * extracted from that file and used as the database name. If not, an exception is thrown.
+	 * extracted from that file and used as the database name. If not, a warning is logged and null is returned.
+	 * Previously, an exception was thrown if the database-name could not be determined, but this raised problems for
+	 * users that had directory names like ".svn" that they could not easily remove (and we can't eagerly ignore certain
+	 * names since something like ".svn" is a valid ML database name).
 	 *
 	 * @param context
 	 * @param configDir
@@ -538,8 +541,10 @@ public abstract class AbstractCommand extends LoggingObject implements Command {
 			}
 		}
 
-		throw new RuntimeException("Could not determine database to associate with database resource directory: " +
-			databaseResourceDir);
+		logger.warn("Could not determine database to associate with database resource directory: " +
+			databaseResourceDir + "; will not process any resource files in that directory");
+
+		return null;
 	}
 
 	public void setPayloadTokenReplacer(PayloadTokenReplacer payloadTokenReplacer) {

--- a/src/main/java/com/marklogic/appdeployer/command/alert/DeployAlertActionsCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/alert/DeployAlertActionsCommand.java
@@ -35,7 +35,9 @@ public class DeployAlertActionsCommand extends AbstractCommand {
 			deployActions(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployActions(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployActions(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/alert/DeployAlertConfigsCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/alert/DeployAlertConfigsCommand.java
@@ -26,7 +26,9 @@ public class DeployAlertConfigsCommand extends AbstractResourceCommand {
 			deployAlertConfigs(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployAlertConfigs(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployAlertConfigs(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/alert/DeployAlertRulesCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/alert/DeployAlertRulesCommand.java
@@ -28,7 +28,9 @@ public class DeployAlertRulesCommand extends AbstractCommand {
 			deployRules(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployRules(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployRules(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/flexrep/DeployConfigsCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/flexrep/DeployConfigsCommand.java
@@ -33,7 +33,9 @@ public class DeployConfigsCommand extends AbstractResourceCommand {
 			deployConfigs(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployConfigs(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployConfigs(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/flexrep/DeployPullsCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/flexrep/DeployPullsCommand.java
@@ -35,7 +35,9 @@ public class DeployPullsCommand extends AbstractResourceCommand {
 			deployFlexRepPulls(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployFlexRepPulls(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployFlexRepPulls(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/flexrep/DeployTargetsCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/flexrep/DeployTargetsCommand.java
@@ -37,7 +37,9 @@ public class DeployTargetsCommand extends AbstractCommand {
 			deployTargets(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployTargets(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployTargets(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/rebalancer/DeployPartitionQueriesCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/rebalancer/DeployPartitionQueriesCommand.java
@@ -27,7 +27,9 @@ public class DeployPartitionQueriesCommand extends AbstractResourceCommand {
 		for (ConfigDir configDir : appConfig.getConfigDirs()) {
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployPartitionQueries(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployPartitionQueries(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/rebalancer/DeployPartitionsCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/rebalancer/DeployPartitionsCommand.java
@@ -27,7 +27,9 @@ public class DeployPartitionsCommand extends AbstractResourceCommand {
 		for (ConfigDir configDir : appConfig.getConfigDirs()) {
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployPartitions(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployPartitions(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/temporal/DeployTemporalAxesCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/temporal/DeployTemporalAxesCommand.java
@@ -28,7 +28,9 @@ public class DeployTemporalAxesCommand extends AbstractResourceCommand {
 			deployTemporalAxes(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployTemporalAxes(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployTemporalAxes(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/temporal/DeployTemporalCollectionsCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/temporal/DeployTemporalCollectionsCommand.java
@@ -29,7 +29,9 @@ public class DeployTemporalCollectionsCommand extends AbstractResourceCommand {
 			deployTemporalCollections(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployTemporalCollections(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployTemporalCollections(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/temporal/DeployTemporalCollectionsLSQTCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/temporal/DeployTemporalCollectionsLSQTCommand.java
@@ -20,7 +20,9 @@ public class DeployTemporalCollectionsLSQTCommand extends AbstractCommand {
 			deployTemporalCollectionsLsqt(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployTemporalCollectionsLsqt(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployTemporalCollectionsLsqt(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/triggers/DeployTriggersCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/triggers/DeployTriggersCommand.java
@@ -37,7 +37,9 @@ public class DeployTriggersCommand extends AbstractResourceCommand {
 			deployTriggers(context, configDir, initialTriggersDatabaseName);
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployTriggers(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployTriggers(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/marklogic/appdeployer/command/viewschemas/DeployViewSchemasCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/viewschemas/DeployViewSchemasCommand.java
@@ -41,7 +41,9 @@ public class DeployViewSchemasCommand extends AbstractResourceCommand {
 			deployViewSchemas(context, configDir, appConfig.getContentDatabaseName());
 			for (File dir : configDir.getDatabaseResourceDirectories()) {
 				String databaseName = determineDatabaseNameForDatabaseResourceDirectory(context, configDir, dir);
-				deployViewSchemas(context, new ConfigDir(dir), databaseName);
+				if (databaseName != null) {
+					deployViewSchemas(context, new ConfigDir(dir), databaseName);
+				}
 			}
 		}
 	}

--- a/src/test/java/com/marklogic/appdeployer/command/alert/ManageAlertConfigsTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/alert/ManageAlertConfigsTest.java
@@ -8,6 +8,11 @@ import com.marklogic.mgmt.resource.alert.AlertConfigManager;
 
 import java.io.File;
 
+/**
+ * This test is also expected to verify the fix for #442, which is that when a database resource directory - in this
+ * case, sample-app/alert-configs/databases/unknown-database - cannot be associated with an existing ML database, an
+ * exception is NOT thrown but rather a warning is logged. The fact that the test succeeds is evidence of this.
+ */
 public class ManageAlertConfigsTest extends AbstractManageResourceTest {
 
 	@Override

--- a/src/test/resources/sample-app/alert-config/databases/unknown-database/alert/configs/should-be-ignored-alert-config.json
+++ b/src/test/resources/sample-app/alert-config/databases/unknown-database/alert/configs/should-be-ignored-alert-config.json
@@ -1,0 +1,9 @@
+{
+  "uri": "should-be-ignored-alert-config",
+  "name": "Should Be Ignored Alerting App",
+  "description": "This should be ignored since the parent directory of 'unknown-database' doesn't match an existing ML database",
+  "trigger": [],
+  "domain": [],
+  "action": [],
+  "option": []
+}


### PR DESCRIPTION
"Isn't valid" = an existing ML database cannot be associated. Now logging a warning as throwing an exception proved to be too punitive for users. 