### PR TITLE
Upgrading dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ repositories {
 }
 
 dependencies {
-  api 'com.marklogic:ml-javaclient-util:4.3.1'
-  api 'org.springframework:spring-web:5.3.18'
-	api 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+  api 'com.marklogic:ml-javaclient-util:4.3.3'
+  api 'org.springframework:spring-web:5.3.22'
+	api 'com.fasterxml.jackson.core:jackson-databind:2.12.6.1'
 
 	implementation 'jaxen:jaxen:1.2.0'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
@@ -48,8 +48,8 @@ dependencies {
 	compileOnly "com.beust:jcommander:1.82"
 	compileOnly "ch.qos.logback:logback-classic:1.2.11"
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"
-	testImplementation 'org.springframework:spring-test:5.3.18'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
+	testImplementation 'org.springframework:spring-test:5.3.22'
 	testImplementation 'commons-io:commons-io:2.11.0'
 	testImplementation 'xmlunit:xmlunit:1.6'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -40,19 +40,19 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>ml-javaclient-util</artifactId>
-      <version>4.3.1</version>
+      <version>4.3.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>5.3.18</version>
+      <version>5.3.22</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.2.2</version>
+      <version>2.12.6.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Also changed jackson-databind dependency to the latest 2.12.6.x release, as Java Client is still on 2.12.x, and ml-javaclient-util is on 2.12.6.x. We can go to 2.13.x across the board once Java Client goes to 2.13.x.