### PR TITLE
DEVEXP-184: Forcing https/443 when using cloud auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,11 @@ java {
 }
 
 repositories {
-	mavenCentral()
+	mavenLocal()
 	maven {
 		url "https://nexus.marklogic.com/repository/maven-snapshots/"
 	}
+	mavenCentral()
 }
 
 // Do not cache changing modules
@@ -30,6 +31,9 @@ configurations.all {
 }
 
 dependencies {
+	api('com.marklogic:marklogic-client-api:6.1-SNAPSHOT') {
+		changing = true
+	}
 	api('com.marklogic:ml-javaclient-util:4.5-SNAPSHOT') {
 		changing = true
 	}

--- a/src/main/java/com/marklogic/mgmt/DefaultManageConfigFactory.java
+++ b/src/main/java/com/marklogic/mgmt/DefaultManageConfigFactory.java
@@ -72,11 +72,6 @@ public class DefaultManageConfigFactory extends PropertySourceFactory implements
 		    }
 	    });
 
-		propertyConsumerMap.put("mlCloudApiKey", (config, prop) -> {
-			logger.info("Setting cloud API key");
-			config.setCloudApiKey(prop);
-		});
-
 		propertyConsumerMap.put("mlManageBasePath", (config, prop) -> {
 			logger.info("Manage base path: " + prop);
 			config.setBasePath(prop);
@@ -130,7 +125,15 @@ public class DefaultManageConfigFactory extends PropertySourceFactory implements
 	    propertyConsumerMap.put("mlSecurityPassword", (config, prop) -> {
 		    config.setSecurityPassword(prop);
 	    });
-    }
+
+		// Processed last so that it can override scheme/port
+		propertyConsumerMap.put("mlCloudApiKey", (config, prop) -> {
+			logger.info("Setting Manage cloud API key and forcing scheme to HTTPS and port to 443");
+			config.setCloudApiKey(prop);
+			config.setScheme("https");
+			config.setPort(443);
+		});
+	}
 
     @Override
     public ManageConfig newManageConfig() {

--- a/src/main/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactory.java
+++ b/src/main/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactory.java
@@ -68,11 +68,6 @@ public class DefaultAdminConfigFactory extends PropertySourceFactory implements 
 		    }
 	    });
 
-		propertyConsumerMap.put("mlCloudApiKey", (config, prop) -> {
-			logger.info("Setting cloud API key");
-			config.setCloudApiKey(prop);
-		});
-
 		propertyConsumerMap.put("mlAdminBasePath", (config, prop) -> {
 			logger.info("Admin base path: " + prop);
 			config.setBasePath(prop);
@@ -102,7 +97,15 @@ public class DefaultAdminConfigFactory extends PropertySourceFactory implements 
 		    logger.info("Using trust management algorithm for SSL for Admin app server: " + prop);
 		    config.setTrustManagementAlgorithm(prop);
 	    });
-    }
+
+		// Processed last so that it can override scheme/port
+		propertyConsumerMap.put("mlCloudApiKey", (config, prop) -> {
+			logger.info("Setting Admin cloud API key and forcing scheme to HTTPS and port to 443");
+			config.setCloudApiKey(prop);
+			config.setPort(443);
+			config.setScheme("https");
+		});
+	}
 
     @Override
     public AdminConfig newAdminConfig() {

--- a/src/main/java/com/marklogic/mgmt/util/SimplePropertySource.java
+++ b/src/main/java/com/marklogic/mgmt/util/SimplePropertySource.java
@@ -9,7 +9,10 @@ public class SimplePropertySource implements PropertySource {
     public SimplePropertySource(String... propNamesAndValues) {
         props = new Properties();
         for (int i = 0; i < propNamesAndValues.length; i += 2) {
-            props.setProperty(propNamesAndValues[i], propNamesAndValues[i + 1]);
+			final String value = propNamesAndValues[i + 1];
+			if (value != null) {
+				props.setProperty(propNamesAndValues[i], value);
+			}
         }
     }
 

--- a/src/main/java/com/marklogic/rest/util/RestTemplateUtil.java
+++ b/src/main/java/com/marklogic/rest/util/RestTemplateUtil.java
@@ -66,7 +66,7 @@ public class RestTemplateUtil {
 	public static RestTemplate newRestTemplate(RestConfig config) {
 		DatabaseClientFactory.Bean bean = config.newDatabaseClientBuilder().buildBean();
 		OkHttpClient client = OkHttpClientBuilderFactory
-			.newOkHttpClientBuilder(bean.getHost(), bean.getPort(), bean.getSecurityContext())
+			.newOkHttpClientBuilder(bean.getHost(), bean.getSecurityContext())
 			.build();
 
 		RestTemplate rt = new RestTemplate(new OkHttp3ClientHttpRequestFactory(client));

--- a/src/test/java/com/marklogic/mgmt/DefaultManageConfigFactoryTest.java
+++ b/src/test/java/com/marklogic/mgmt/DefaultManageConfigFactoryTest.java
@@ -1,10 +1,10 @@
 package com.marklogic.mgmt;
 
-import com.marklogic.mgmt.admin.AdminConfig;
-import com.marklogic.mgmt.admin.DefaultAdminConfigFactory;
 import com.marklogic.mgmt.util.SimplePropertySource;
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultManageConfigFactoryTest  {
 
@@ -103,11 +103,16 @@ public class DefaultManageConfigFactoryTest  {
 	void cloudApiKeyAndBasePath() {
 		ManageConfig config = configure(
 			"mlCloudApiKey", "my-key",
-			"mlManageBasePath", "/manage/path"
+			"mlManageBasePath", "/manage/path",
+			"mlManagePort", "8002",
+			"mlManageScheme", "http"
 		);
 
 		assertEquals("my-key", config.getCloudApiKey());
 		assertEquals("/manage/path", config.getBasePath());
+		assertEquals(443, config.getPort(), "When a cloud API key is provided, the mlManagePort and mlManageScheme " +
+			"options should be overridden since https/443 are guaranteed to be the correct values");
+		assertEquals("https", config.getScheme());
 	}
 
 	private ManageConfig configure(String... properties) {

--- a/src/test/java/com/marklogic/mgmt/TestConfig.java
+++ b/src/test/java/com/marklogic/mgmt/TestConfig.java
@@ -1,5 +1,7 @@
 package com.marklogic.mgmt;
 
+import com.marklogic.mgmt.admin.DefaultAdminConfigFactory;
+import com.marklogic.mgmt.util.SimplePropertySource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,32 +18,32 @@ import com.marklogic.mgmt.admin.AdminConfig;
 @PropertySource(value = { "classpath:test.properties", "classpath:user.properties" }, ignoreResourceNotFound = true)
 public class TestConfig {
 
-    @Value("${mlManageHost:localhost}")
+    @Value("${mlHost:localhost}")
     private String host;
 
-	@Value("${mlManagePort:8002}")
+	@Value("${mlManagePort:#{NULL}}")
 	private Integer managePort;
 
-	@Value("${mlAdminPort:8001}")
+	@Value("${mlAdminPort:#{NULL}}")
 	private Integer adminPort;
 
-    @Value("${mlManageUsername:admin}")
+    @Value("${mlUsername:#{NULL}}")
     private String username;
 
-    @Value("${mlManagePassword:}")
+    @Value("${mlPassword:#{NULL}}")
     private String password;
 
-	@Value("${mlBasePath:}")
+	@Value("${mlBasePath:#{NULL}}")
 	private String basePath;
 
-	@Value("${mlCloudApiKey:}")
+	@Value("${mlCloudApiKey:#{NULL}}")
 	private String cloudApiKey;
 
-	@Value("${mlScheme:http}")
+	@Value("${mlScheme:#{NULL}}")
 	private String scheme;
 
-	@Value("${mlSimpleSsl:false}")
-	private boolean simpleSsl;
+	@Value("${mlSimpleSsl:#{NULL}}")
+	private Boolean simpleSsl;
 
     /**
      * Has to be static so that Spring instantiates it first.
@@ -55,13 +57,16 @@ public class TestConfig {
 
     @Bean
     public ManageConfig manageConfig() {
-        ManageConfig config = new ManageConfig(host, managePort, username, password);
-		config.setBasePath(basePath);
-		config.setCloudApiKey(cloudApiKey);
-		config.setScheme(scheme);
-		if (simpleSsl) {
-			config.setConfigureSimpleSsl(true);
-		}
+		ManageConfig config = new DefaultManageConfigFactory(new SimplePropertySource(
+			"mlHost", host,
+			"mlManagePort", managePort != null ? managePort.toString() : null,
+			"mlUsername", username,
+			"mlPassword", password,
+			"mlManageBasePath", basePath,
+			"mlCloudApiKey", cloudApiKey,
+			"mlManageScheme", scheme,
+			"mlManageSimpleSsl", simpleSsl != null ? simpleSsl.toString() : null
+		)).newManageConfig();
         // Clean the JSON by default
 	    config.setCleanJsonPayloads(true);
 	    return config;
@@ -72,13 +77,15 @@ public class TestConfig {
      */
     @Bean
     public AdminConfig adminConfig() {
-        AdminConfig config = new AdminConfig(host, adminPort, username, password);
-		config.setBasePath(basePath);
-		config.setCloudApiKey(cloudApiKey);
-		config.setScheme(scheme);
-		if (simpleSsl) {
-			config.setConfigureSimpleSsl(true);
-		}
-		return config;
+		return new DefaultAdminConfigFactory(new SimplePropertySource(
+			"mlHost", host,
+			"mlAdminPort", adminPort != null ? adminPort.toString() : null,
+			"mlUsername", username,
+			"mlPassword", password,
+			"mlAdminBasePath", basePath,
+			"mlCloudApiKey", cloudApiKey,
+			"mlAdminScheme", scheme,
+			"mlAdminSimpleSsl", simpleSsl != null ? simpleSsl.toString() : null
+		)).newAdminConfig();
     }
 }

--- a/src/test/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactoryTest.java
+++ b/src/test/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactoryTest.java
@@ -1,10 +1,10 @@
 package com.marklogic.mgmt.admin;
 
-import com.marklogic.appdeployer.AppConfig;
-import com.marklogic.appdeployer.DefaultAppConfigFactory;
 import com.marklogic.mgmt.util.SimplePropertySource;
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultAdminConfigFactoryTest  {
 
@@ -61,11 +61,15 @@ public class DefaultAdminConfigFactoryTest  {
 	void cloudApiKeyAndBasePath() {
 		AdminConfig config = new DefaultAdminConfigFactory(new SimplePropertySource(
 			"mlCloudApiKey", "my-key",
-			"mlAdminBasePath", "/admin/path"
+			"mlAdminBasePath", "/admin/path",
+			"mlAdminPort", "8001",
+			"mlAdminScheme", "http"
 		)).newAdminConfig();
 
 		assertEquals("my-key", config.getCloudApiKey());
 		assertEquals("/admin/path", config.getBasePath());
+		assertEquals(443, config.getPort(), "When a cloud API key is provided, https and 443 should be assumed");
+		assertEquals("https", config.getScheme());
 	}
 
 	private AdminConfig configure(String... properties) {

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,9 +1,15 @@
 # Properties for connecting to the Mgmt API; port 8002 is assumed
 # Can override these files via a gitignored "user.properties" file in this same directory
-mlManageHost=localhost
-mlManageUsername=admin
-mlManagePassword=admin
+mlHost=localhost
+
+# When testing MarkLogic Cloud manually, comment these out for a more realistic test (it's fine to leave them
+# uncommented, as they'll be ignored, it's just more realistic to comment them out).
+mlUsername=admin
+mlPassword=admin
 mlManagePort=8002
 mlAdminPort=8001
-mlScheme=http
-mlSimpleSsl=false
+
+# When testing MarkLogic Cloud manually, you'll need to set these in user.properties:
+# mlHost=the name of the host
+# mlCloudApiKey=the key value
+# mlBasePath=the base path for the Manage app server


### PR DESCRIPTION
Prevents the user from having to remember to set the manage port to 443 instead of 8002 and the admin port to 443 instead of 8001. 