### PR TITLE
Providing helpful error context when connection fails

### DIFF
--- a/src/main/java/com/marklogic/mgmt/ManageConfig.java
+++ b/src/main/java/com/marklogic/mgmt/ManageConfig.java
@@ -62,11 +62,6 @@ public class ManageConfig extends RestConfig {
 		this.securitySslContext = other.securitySslContext;
 		this.cleanJsonPayloads = other.cleanJsonPayloads;
 	}
-	@Override
-	public String toString() {
-		return String.format("[ManageConfig host: %s, port: %d, username: %s, security username: %s]", getHost(),
-			getPort(), getUsername(), getSecurityUsername());
-	}
 
 	public boolean isCleanJsonPayloads() {
 		return cleanJsonPayloads;

--- a/src/main/java/com/marklogic/rest/util/RestConfig.java
+++ b/src/main/java/com/marklogic/rest/util/RestConfig.java
@@ -110,7 +110,7 @@ public class RestConfig {
 
 	@Override
 	public String toString() {
-		return String.format("[scheme: %s, host: %s, port: %d, username: %s]", scheme, host, port, username);
+		return String.format("%s://%shost:%d", getScheme(), getHost(), getPort());
 	}
 
 	/**

--- a/src/main/java/com/marklogic/rest/util/RestTemplateUtil.java
+++ b/src/main/java/com/marklogic/rest/util/RestTemplateUtil.java
@@ -64,10 +64,15 @@ public class RestTemplateUtil {
 	 * @return
 	 */
 	public static RestTemplate newRestTemplate(RestConfig config) {
-		DatabaseClientFactory.Bean bean = config.newDatabaseClientBuilder().buildBean();
-		OkHttpClient client = OkHttpClientBuilderFactory
-			.newOkHttpClientBuilder(bean.getHost(), bean.getSecurityContext())
-			.build();
+		OkHttpClient client;
+		try {
+			DatabaseClientFactory.Bean bean = config.newDatabaseClientBuilder().buildBean();
+			client = OkHttpClientBuilderFactory
+				.newOkHttpClientBuilder(bean.getHost(), bean.getSecurityContext())
+				.build();
+		} catch (RuntimeException ex) {
+			throw new RuntimeException(String.format("Unable to connect to the MarkLogic app server at %s; cause: %s", config.toString(), ex.getMessage()));
+		}
 
 		RestTemplate rt = new RestTemplate(new OkHttp3ClientHttpRequestFactory(client));
 		rt.setErrorHandler(new MgmtResponseErrorHandler());

--- a/src/test/java/com/marklogic/rest/util/RestTemplateUtilTest.java
+++ b/src/test/java/com/marklogic/rest/util/RestTemplateUtilTest.java
@@ -12,6 +12,7 @@ import javax.net.ssl.SSLContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -116,5 +117,18 @@ public class RestTemplateUtilTest extends BaseTestHelper {
 		} catch (Exception ex) {
 			logger.info("Caught expected exception: " + ex.getMessage());
 		}
+	}
+
+	@Test
+	void noUsername() {
+		manageConfig.setUsername(null);
+		RuntimeException ex = assertThrows(RuntimeException.class,
+			() -> RestTemplateUtil.newRestTemplate(manageConfig));
+
+		assertEquals("Unable to connect to the MarkLogic app server at http://localhosthost:8002; cause: username must be of type String",
+			ex.getMessage(),
+			"As of 4.5.0, since auth strategies other than basic/digest are now supported, the error message is expected " +
+				"to identify which MarkLogic app server is being accessed but not any authentication details. This is " +
+				"due to a change to toString of RestConfig/ManageConfig so that a username is not logged.");
 	}
 }


### PR DESCRIPTION
Intent is to identify the app server that RestTemplateUtil is trying to access, but also to no longer assume that a username is being used. 