### PR TITLE
Improving handling of deleting a REST API server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.marklogic"
-version = "4.5.2"
+version = "4.5-SNAPSHOT"
 
 java {
 	sourceCompatibility = 1.8

--- a/src/main/java/com/marklogic/mgmt/resource/restapis/RestApiManager.java
+++ b/src/main/java/com/marklogic/mgmt/resource/restapis/RestApiManager.java
@@ -105,13 +105,24 @@ public class RestApiManager extends LoggingObject {
 				PayloadParser parser = new PayloadParser();
 
 				if (request.isIncludeModules()) {
+					boolean includeModules = true;
 					if (request.isDeleteModulesReplicaForests()) {
-						String modulesDatabase = parser.getPayloadFieldValue(payload, "modules-database");
-						if (databaseManager.exists(modulesDatabase)) {
+						String modulesDatabase = null;
+						try {
+							modulesDatabase = parser.getPayloadFieldValue(payload, "modules-database");
+						} catch (Exception e) {
+							logger.warn("Unable to get value of `modules-database`; will not be able to delete " +
+								"modules database. This may be expected if the modules database has been set to " +
+								"'filesystem' for the app server. Error: {}", e.getMessage());
+							includeModules = false;
+						}
+						if (modulesDatabase != null && databaseManager.exists(modulesDatabase)) {
 							databaseManager.deleteReplicaForests(modulesDatabase);
 						}
 					}
-					path += "include=modules&";
+					if (includeModules) {
+						path += "include=modules&";
+					}
 				}
 
 				if (request.isIncludeContent()) {

--- a/src/main/java/com/marklogic/rest/util/MgmtResponseErrorHandler.java
+++ b/src/main/java/com/marklogic/rest/util/MgmtResponseErrorHandler.java
@@ -18,6 +18,7 @@ package com.marklogic.rest.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.HttpClientErrorException;
@@ -49,6 +50,14 @@ public class MgmtResponseErrorHandler extends DefaultResponseErrorHandler {
 				logger.error(message);
 			}
 			throw ex;
+		} catch (InvalidMediaTypeException ex) {
+			// In at least one scenario - when deleting a REST API server whose modules database has been set to be
+			// the filesystem (which is not a valid setup, but a user may still do it), MarkLogic returns a mime type
+			// containing commas - e.g. "text/plain, application/json". And Spring does not like that and throws this
+			// error. That obscures the actual error. So a runtime exception is thrown with the mime type error but
+			// also the response body from MarkLogic, which will contain the actual error.
+			String body = new String(getResponseBody(response));
+			throw new RuntimeException("Unable to parse mime type: " + ex.getMessage() + "; response body from MarkLogic: " + body);
 		}
 	}
 


### PR DESCRIPTION
Unfortunately the scenario in question - when a user has changed their modules-database to the filesystem - cannot be fully supported yet due to a server bug. But this at least exposes a better error to the user, which is currently being obscured by the error due to the invalid MIME type from the call to DELETE /v1/rest-apis.